### PR TITLE
Feat/lock

### DIFF
--- a/src/main/java/no/gunbang/market/common/Inventory.java
+++ b/src/main/java/no/gunbang/market/common/Inventory.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,6 +25,10 @@ public class Inventory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Version
+    @Comment("낙관적 락을 위한 엔티티 버전")
+    private Long version;
 
     @Comment("아이템 외래키")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/no/gunbang/market/common/LockStrategyConfig.java
+++ b/src/main/java/no/gunbang/market/common/LockStrategyConfig.java
@@ -1,0 +1,45 @@
+package no.gunbang.market.common;
+
+import no.gunbang.market.common.lock.NamedLockImpl;
+import no.gunbang.market.common.lock.OptimisticLockImpl;
+import no.gunbang.market.common.lock.PessimisticLockImpl;
+import no.gunbang.market.common.lock.ReentrantLockImpl;
+import no.gunbang.market.common.lock.SynchronizedLockImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+public class LockStrategyConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "lock.strategy", havingValue = "synchronized")
+    public SynchronizedLockImpl synchronizedLock() {
+        return new SynchronizedLockImpl();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "lock.strategy", havingValue = "reentrant")
+    public ReentrantLockImpl ReentrantLock() {
+        return new ReentrantLockImpl();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "lock.strategy", havingValue = "optimistic")
+    public OptimisticLockImpl optimisticLock() {
+        return new OptimisticLockImpl();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "lock.strategy", havingValue = "pessimistic")
+    public PessimisticLockImpl pessimisticLock() {
+        return new PessimisticLockImpl();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "lock.strategy", havingValue = "named")
+    public NamedLockImpl NamedLock(JdbcTemplate jdbcTemplate) {
+        return new NamedLockImpl(jdbcTemplate);
+    }
+}

--- a/src/main/java/no/gunbang/market/common/lock/LockStrategy.java
+++ b/src/main/java/no/gunbang/market/common/lock/LockStrategy.java
@@ -1,0 +1,14 @@
+package no.gunbang.market.common.lock;
+
+import java.util.function.Supplier;
+
+public interface LockStrategy {
+
+    boolean lock(String lockKey, long waitTime, long leaseTime);
+
+    void unlock(String lockKey);
+
+    <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier);
+
+    <T> T execute(Class<T> entityClass, Object lockKey, long waitTime, long leaseTime, Supplier<T> supplier);
+}

--- a/src/main/java/no/gunbang/market/common/lock/NamedLockImpl.java
+++ b/src/main/java/no/gunbang/market/common/lock/NamedLockImpl.java
@@ -1,0 +1,46 @@
+package no.gunbang.market.common.lock;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RequiredArgsConstructor
+public class NamedLockImpl implements LockStrategy{
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public boolean lock(String lockKey, long waitTime, long leaseTime) {
+        // MySQL timeout 단위는 초이므로, waitTime(ms)를 초로 변환
+        int timeout = (int) (waitTime / 1000);
+        Boolean result = jdbcTemplate.queryForObject(
+            "SELECT GET_LOCK(?, ?)",
+            new Object[]{lockKey, timeout},
+            Boolean.class);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Override
+    public void unlock(String lockKey) {
+        jdbcTemplate.queryForObject("SELECT RELEASE_LOCK(?)", new Object[]{lockKey}, Boolean.class);
+    }
+
+    @Override
+    public <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+
+        if (!lock(lockKey, waitTime, leaseTime)) {
+            throw new RuntimeException("락 획득 실패");
+        }
+        try {
+            return supplier.get();
+        } finally {
+            unlock(lockKey);
+        }
+    }
+
+    @Override
+    public <T> T execute(Class<T> entityClass, Object lockKey, long waitTime, long leaseTime,
+        Supplier<T> supplier) {
+        return execute(String.valueOf(lockKey), waitTime, leaseTime, supplier);
+    }
+}

--- a/src/main/java/no/gunbang/market/common/lock/OptimisticLockImpl.java
+++ b/src/main/java/no/gunbang/market/common/lock/OptimisticLockImpl.java
@@ -1,0 +1,37 @@
+package no.gunbang.market.common.lock;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import java.util.function.Supplier;
+
+public class OptimisticLockImpl implements LockStrategy {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public boolean lock(String lockKey, long waitTime, long leaseTime) {
+        return true;            // 별도의 획득 없음
+    }
+
+    @Override
+    public void unlock(String lockKey) {
+                                // 마찬가지로 transaction 종료 시 해제
+    }
+
+    @Override
+    public <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        return null;
+    }
+
+
+    @Override
+    public <T> T execute(Class<T> entityClass, Object primaryKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+
+        // 엔티티를 조회해서 버전확인
+        entityManager.find(entityClass, primaryKey, LockModeType.OPTIMISTIC);
+
+        return supplier.get();
+    }
+}

--- a/src/main/java/no/gunbang/market/common/lock/PessimisticLockImpl.java
+++ b/src/main/java/no/gunbang/market/common/lock/PessimisticLockImpl.java
@@ -1,0 +1,37 @@
+package no.gunbang.market.common.lock;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import java.util.function.Supplier;
+
+public class PessimisticLockImpl implements LockStrategy {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public boolean lock(String lockKey, long waitTime, long leaseTime) {
+        return true;    // 데이터베이스에서 제공하는 행 수준 락을 활용하므로 호출할 필요 X
+    }
+
+    @Override
+    public void unlock(String lockKey) {
+                        // 트랜잭션 종료 시 자동 해제
+    }
+
+    @Override
+    public <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        return null;
+    }
+
+    @Override
+    public <T> T execute(Class<T> entityClass, Object lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        T entity = entityManager.find(entityClass, lockKey, LockModeType.PESSIMISTIC_WRITE);
+        if (entity == null) {
+            throw new RuntimeException("엔티티를 찾을 수 없습니다.");
+        }
+        return supplier.get();
+    }
+
+}

--- a/src/main/java/no/gunbang/market/common/lock/ReentrantLockImpl.java
+++ b/src/main/java/no/gunbang/market/common/lock/ReentrantLockImpl.java
@@ -1,0 +1,52 @@
+package no.gunbang.market.common.lock;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+public class ReentrantLockImpl implements LockStrategy{
+
+    private final ConcurrentHashMap<String, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean lock(String lockKey, long waitTime, long leaseTime) {
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock(true));
+        try {
+            return lock.tryLock(waitTime, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    @Override
+    public void unlock(String lockKey) {
+        ReentrantLock lock = lockMap.get(lockKey);
+        if (lock != null && lock.isHeldByCurrentThread()) {
+            lock.unlock();
+            // 대기 중인 스레드가 없으면 맵에서 제거
+            if (!lock.hasQueuedThreads()) {
+                lockMap.remove(lockKey);
+            }
+        }
+    }
+
+    @Override
+    public <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+
+        if (!lock(lockKey, waitTime, leaseTime)) {
+            throw new RuntimeException("락 획득 실패: " + lockKey);
+        }
+        try {
+            return supplier.get();
+        } finally {
+            unlock(lockKey);
+        }
+    }
+
+    @Override
+    public <T> T execute(Class<T> entityClass, Object lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        return execute(String.valueOf(lockKey), waitTime, leaseTime, supplier);
+    }
+}

--- a/src/main/java/no/gunbang/market/common/lock/SynchronizedLockImpl.java
+++ b/src/main/java/no/gunbang/market/common/lock/SynchronizedLockImpl.java
@@ -1,0 +1,35 @@
+package no.gunbang.market.common.lock;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public class SynchronizedLockImpl implements LockStrategy {
+
+    // lockKey별로 동기화할 객체를 관리
+    private final ConcurrentHashMap<String, Object> lockMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean lock(String lockKey, long waitTime, long leaseTime) {
+        return true;        // 별도의 획득 로직이 없다
+    }
+
+    @Override
+    public void unlock(String lockKey) {
+                            // 역시 synchronized 블록을 벗어나면 자동으로 해제
+    }
+
+    @Override
+    public <T> T execute(String lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        // lockKey 별로 고유한 락 객체를 사용하여 동기화
+        Object lockObject = lockMap.computeIfAbsent(lockKey, k -> new Object());
+
+        synchronized (lockObject) {
+            return supplier.get();
+        }
+    }
+
+    @Override
+    public <T> T execute(Class<T> entityClass, Object lockKey, long waitTime, long leaseTime, Supplier<T> supplier) {
+        return execute(String.valueOf(lockKey), waitTime, leaseTime, supplier);
+    }
+}

--- a/src/main/java/no/gunbang/market/domain/market/entity/Market.java
+++ b/src/main/java/no/gunbang/market/domain/market/entity/Market.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,11 +29,16 @@ import org.hibernate.annotations.Comment;
 @NoArgsConstructor
 public class Market extends BaseEntity {
 
+
     @Comment("거래소 식별자")
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(columnDefinition = "BIGINT")
     private Long id;
+
+    @Version
+    @Comment("낙관적 락을 위한 엔티티 버전")
+    private Long version;
 
     @Comment("아이템 수량")
     private int amount;

--- a/src/main/java/no/gunbang/market/domain/market/service/InventoryService.java
+++ b/src/main/java/no/gunbang/market/domain/market/service/InventoryService.java
@@ -6,6 +6,7 @@ import no.gunbang.market.common.InventoryRepository;
 import no.gunbang.market.common.Item;
 import no.gunbang.market.common.exception.CustomException;
 import no.gunbang.market.common.exception.ErrorCode;
+import no.gunbang.market.common.lock.LockStrategy;
 import no.gunbang.market.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class InventoryService {
 
     private final InventoryRepository inventoryRepository;
+    private final LockStrategy lockStrategy;
 
     public void updateInventory(Item item, User user, int amount) {
 
@@ -30,12 +32,18 @@ public class InventoryService {
             inventoryRepository.save(inventory);
             return;
         }
+
+        final Inventory currentInventory = inventory;
         // 구매자는 아이템 수 증가 판매자는 감소 후 setter 호출
-        int newAmount = inventory.getAmount() + amount;
-        if (newAmount < 0) {
-            throw new CustomException(ErrorCode.LACK_OF_SELLER_INVENTORY);
-        }
-        inventory.setAmount(newAmount);
+        lockStrategy.execute(Inventory.class, inventory.getId(), 1000L, 3000L, () -> {
+            int newAmount = currentInventory.getAmount() + amount;
+            if (newAmount < 0) {
+                throw new CustomException(ErrorCode.LACK_OF_SELLER_INVENTORY);
+            }
+            currentInventory.setAmount(newAmount);
+            inventoryRepository.save(currentInventory);
+            return null;
+        });
     }
 
 }

--- a/src/main/java/no/gunbang/market/domain/user/entity/User.java
+++ b/src/main/java/no/gunbang/market/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import no.gunbang.market.common.exception.CustomException;
@@ -18,11 +19,16 @@ import org.hibernate.annotations.Comment;
 @NoArgsConstructor
 public class User {
 
+
     @Comment("사용자 식별자")
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(columnDefinition = "BIGINT")
     private Long id;
+
+    @Version
+    @Comment("낙관적 락을 위한 엔티티 버전")
+    private Long version;
 
     @Comment("닉네임")
     @Column(unique = true)

--- a/src/main/resources/fill_version.sql
+++ b/src/main/resources/fill_version.sql
@@ -1,0 +1,12 @@
+use market
+UPDATE inventory
+SET version = 0
+WHERE version IS NULL;
+
+UPDATE user
+SET version = 0
+WHERE version IS NULL;
+
+UPDATE market
+SET version = 0
+WHERE version IS NULL;


### PR DESCRIPTION
## #️⃣ Kan Board Number

61 62 63

## 📝 요약

전략 패턴을 사용하여 공통 인터페이스를 정의하고 거기에 따른 구현체들을 만들었습니다
그리고 Bean 등록을 이용하여 properties 에서 락 구현체를 갈아 끼워서 사용하게끔 하였습니다
거래소에서 동시성이 일어나는 부분인
- 거래 등록시 판매자의 인벤토리에 해당 아이템 차감
- 아이템 구매시 마켓의 아이템 차감
- 구매자의 인벤토리에 해당 아이템 증가
- 구매자의 골드 차감
- 거래 등록 취소 시 판매자의 인벤토리에 마켓의 남은 아이템 증가

에 락을 적용하여 제어하도록 하였습니다

그리고 동시성이 일어나는 엔티티인 유저, 인벤토리, 마켓의 필드에
낙관적 락을 위한 Long타입의 version을 선언하여 버전관리를 하게끔 하였습니다

그리고 해당 로직들이 포함되있는 api를 포스트맨에서 각각의 락 구현체를 적용시킨 다음에 테스트 완료하엿습니다. 

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

이 밖에 거래 등록할 때 마켓의 생성 이라든지 아이템 구매시 없던 해당 아이템의 인벤토리 생성이라든지
데이터 생성에 있어서 동시 생성이 생긴다 가정하고 이 부분에 락을 적용 할건지 만약에 적용한다면
DB 기반 락( 낙관적 락, 비관적 락 ) 을 적용하지 못하므로 논의 후에 인메모리 락이나 분산 락 중
어떤걸 사용할지 논의후에 결정해야할 것 같습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)
